### PR TITLE
allow building universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
when installing this library using pip, it will download a tarball and build a wheel locally:

```
Collecting hcsr04sensor
Using cached https://files.pythonhosted.org/packages/2a/9e/e6523c3f2788632b0dff58ad31236e1c332b4acc3bc47d78532ede3aa52a/hcsr04sensor-1.6.2.tar.gz
...
Building wheel for hcsr04sensor (setup.py) ... done
```

This pr adds a setup.cfg so you can publish a wheel file (as well) that works for both python 2 and 3.

```
python3 setup.py sdist bdist_wheel
```

see https://packaging.python.org/tutorials/packaging-projects/#generating-distribution-archives